### PR TITLE
Fix Ansible package dependencies

### DIFF
--- a/ansible.sh
+++ b/ansible.sh
@@ -4,6 +4,9 @@ set -e
 echo "#############################################################################################"
 echo "########################### Prepare StackStorm and Ansible ##################################"
 
+# Install Ansible core dependencies
+sudo apt-get install -y gcc libkrb5-dev
+
 # Install ansible integration pack
 st2 pack install ansible
 


### PR DESCRIPTION
Fixes #17

Ansible pip requires new lib dependencies.

`sudo apt-get install gcc libkrb5-dev` should fix it.